### PR TITLE
Improve font appearance on Safari iOS

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,8 +4,14 @@
     import PWAReloadPrompt from "./components/PWAReloadPrompt.svelte";
 
     //  Fonts
-    import "@fontsource/ibm-plex-sans"
-    import "@fontsource/space-grotesk"
+    import "@fontsource/space-grotesk/400.css"
+    import "@fontsource/space-grotesk/600.css"
+
+    import "@fontsource/ibm-plex-sans/300.css"
+    import "@fontsource/ibm-plex-sans/400.css"
+    import "@fontsource/ibm-plex-sans/500.css"
+    import "@fontsource/ibm-plex-sans/600.css"
+    import "@fontsource/ibm-plex-sans/700.css"
 </script>
 
 <Router {routes}/>


### PR DESCRIPTION
On Safari iOS we see very weird spacing / weight for fonts (especially Space Grotesk). Explicitly importing all of our font weights may help.